### PR TITLE
Fixing typo in translation scheme for homepage

### DIFF
--- a/artifice/resources/translation_scheme.csv
+++ b/artifice/resources/translation_scheme.csv
@@ -21,7 +21,7 @@ Major update available for PIRANHA software to version,Une mise à jour majeure 
 Install update to RAMPART software,Mettez à jour le logiciel RAMPART
 RAMPART software version,le logiciel RAMPART version
 installed, est installé
-PIRANHA software version,le logiciel RAMPART version
+PIRANHA software version,le logiciel PIRANHA version
 Install update to PIRANHA software,Mettez à jour le logiciel PIRANHA
 PiranhaGUI update available to,mise à jour de PiranhaGUI disponible à
 Open Github download page in browser, Ouvrez la page de téléchargement a Github dans le navigateur 


### PR DESCRIPTION
Fixing typo in translation scheme csv for homepage where it was showing 'RAMPART' on the Piranha line in French mode